### PR TITLE
implement new "activation" mechanism -> using dict, module name or module for `requirement`

### DIFF
--- a/elements_ephys/ephys.py
+++ b/elements_ephys/ephys.py
@@ -13,8 +13,6 @@ from . import probe
 
 schema = dj.schema()
 
-
-
 required_upstream_tables = ("Session", "SkullReference")
 required_functions = ("get_neuropixels_data_directory", "get_paramset_idx", "get_kilosort_output_directory")
 

--- a/elements_ephys/ephys.py
+++ b/elements_ephys/ephys.py
@@ -234,11 +234,11 @@ class ClusteringParamSet(dj.Lookup):
         q_param = cls & {'param_set_hash': param_dict['param_set_hash']}
 
         if q_param:  # If the specified param-set already exists
-            pname = q_param.fetch1('param_set_name')
-            if pname == paramset_idx:  # If the existed set has the same name: job done
+            pname = q_param.fetch1('paramset_idx')
+            if pname == paramset_idx:  # If the existing set has the same paramset_idx: job done
                 return
             else:  # If not same name: human error, trying to add the same paramset with different name
-                raise dj.DataJointError('The specified param-set already exists - name: {}'.format(pname))
+                raise dj.DataJointError('The specified param-set already exists - paramset_idx: {}'.format(pname))
         else:
             cls.insert1(param_dict)
 


### PR DESCRIPTION
With this, users can activate the `ephys` element in 3 ways:

```
from elements_ephys import probe, ephys

from .paths import get_ephys_probe_data_dir as get_neuropixels_data_directory
from .paths import get_ks_data_dir as get_kilosort_output_directory
from .paths import get_paramset_idx as get_paramset_idx
```

```
# activate with a dictionary for requirement
ephys.activate(db_prefix + 'ephys', db_prefix + 'probe',
               ephys_requirement=dict(
                   # upstream tables
                   Session=Session,
                   SkullReference=SkullReference,
                   # functions
                   get_neuropixels_data_directory=get_neuropixels_data_directory,
                   get_paramset_idx=get_paramset_idx,
                   get_kilosort_output_directory=get_kilosort_output_directory))
```

```
# activate with a module name for requirement
ephys.activate(db_prefix + 'ephys', db_prefix + 'probe',
               ephys_requirement=__name__)
```

```
# activate with a module for requirement
import sys
ephys.activate(db_prefix + 'ephys', db_prefix + 'probe',
               ephys_requirement=sys.modules[__name__])
```


For convenience, users can also do:
`ephys.required_upstream_tables`
or
`ephys.required_functions`
to quickly get what are the requirements for this `ephys` element